### PR TITLE
fix: allow transact iframe to copy to clipboard

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ let atomicSDK = {
     }
 
     let iframeElement = document.createElement('iframe')
-    iframeElement.setAttribute('allow', 'web-share')
+    iframeElement.setAttribute('allow', 'web-share; clipboard-write;')
     const productType = config.operation || config.product || 'Atomic'
     iframeElement.setAttribute('title', `${productType} Interface`)
     iframeElement.setAttribute('aria-label', `${productType} Interface`)

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -4,7 +4,7 @@ exports[`JavaScript SDK should initialize the sdk 1`] = `
 [
   [
     "allow",
-    "web-share",
+    "web-share; clipboard-write;",
   ],
   [
     "title",


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/DD-2268/transact-allow-transact-iframe-to-use-clipboard-write-permission

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
